### PR TITLE
docs(ip): clarify comments for GetLocation and GetLocaHonst

### DIFF
--- a/ip/ip.go
+++ b/ip/ip.go
@@ -7,7 +7,14 @@ import (
 	"net/http"
 )
 
-// 获取外网ip地址
+// GetLocation 根据传入的 IP 地址查询归属地（省份-城市）。
+//
+// 处理规则：
+//  1. 当 ip 为 "127.0.0.1" 或 "localhost" 时，直接返回 "内部IP"。
+//  2. 通过高德 IP 定位接口查询公网 IP 对应地理位置。
+//  3. 若查询结果中省份为空，则返回 "未知位置"。
+//
+// 返回值示例："广东省-深圳市"。
 func GetLocation(ip string) string {
 	if ip == "127.0.0.1" || ip == "localhost" {
 		return "内部IP"
@@ -31,7 +38,13 @@ func GetLocation(ip string) string {
 	return m["province"] + "-" + m["city"]
 }
 
-// 获取局域网ip地址
+// GetLocaHonst 获取当前机器可用的局域网 IPv4 地址。
+//
+// 实现逻辑：
+//  1. 遍历所有网络接口，仅处理状态为 up 的接口。
+//  2. 遍历接口地址，过滤掉回环地址（如 127.0.0.1）。
+//  3. 返回第一个匹配到的 IPv4 字符串。
+//  4. 若未找到可用 IPv4，则返回空字符串。
 func GetLocaHonst() string {
 	netInterfaces, err := net.Interfaces()
 	if err != nil {


### PR DESCRIPTION
### Motivation
- Improve code readability by providing clear, structured documentation for the IP helper functions in `ip/ip.go` so callers understand inputs, behavior and return values.

### Description
- Add detailed doc comments to `GetLocation` describing handling for local addresses, usage of the Gaode (高德) IP lookup, and the returned "省份-城市" format, and to `GetLocaHonst` describing the interface/address filtering logic and return behavior, with no changes to runtime logic.

### Testing
- No automated tests were run because this is a documentation-only change to `ip/ip.go` and does not modify program behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14638b8398832ebef95994fd61c8ec)